### PR TITLE
Add support for proxy from environment variable

### DIFF
--- a/privacyidea_radius.pm
+++ b/privacyidea_radius.pm
@@ -352,6 +352,7 @@ sub authenticate {
     }
 
     my $ua     = LWP::UserAgent->new();
+    $ua->env_proxy;
     # Set the user-agent to be fetched in privacyIDEA Client Application Type
     $ua->agent("FreeRADIUS");
 	if ($check_ssl == false) {


### PR DESCRIPTION
If the environment variable is not defined, the setting is not applied.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/FreeRADIUS/pull/3?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/FreeRADIUS/pull/3'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>