### PR TITLE
Use the generic subdir from JSON response

### DIFF
--- a/privacyidea_radius.pm
+++ b/privacyidea_radius.pm
@@ -272,7 +272,7 @@ sub mapResponse {
 					$attributevalue = $decoded->{detail}{$userAttribute};
 					&radiusd::radlog( Info, "++++++ no directory");
 				} else {
-					$attributevalue = $decoded->{detail}{user}{$userAttribute};
+					$attributevalue = $decoded->{detail}{$directory}{$userAttribute};
 					&radiusd::radlog( Info, "++++++ searching in directory $directory");
 				}
 				my @values = ();


### PR DESCRIPTION
The default mostly used subdir would be "detail"->"user".
But in rlm_perl.ini we actually could change the "user" to any other
value.

Fixes #12