### PR TITLE
Fix mods-perl-privacyidea module for FreeRADIUS 2

### DIFF
--- a/config/freeradius2/mods-perl-privacyidea
+++ b/config/freeradius2/mods-perl-privacyidea
@@ -1,3 +1,3 @@
 perl {
-    filename = /usr/share/privacyidea/freeradius/privacyidea_radius.pm
+    module = /usr/share/privacyidea/freeradius/privacyidea_radius.pm
 }


### PR DESCRIPTION
I think there's an incompatibility between the rlm_perl modules of FreeRADIUS 2 and 3 here.
Under FreeRADIUS 2, the ``module`` parameter points to the actual Perl module. Under FreeRADIUS 3, this parameter is called ``filename``.
So we need to use ``module`` in case of FreeRADIUS 2 :)