### PR TITLE
comment serial

### DIFF
--- a/rlm_perl.ini
+++ b/rlm_perl.ini
@@ -5,8 +5,8 @@ URL = https://localhost/validate/check
 SSL_CHECK = false
 #DEBUG = true
 
-[Mapping]
-serial = privacyIDEA-Serial
+#[Mapping]
+#serial = privacyIDEA-Serial
 
 [Mapping user]
 # The Mapping is used to add attributes to the RADIUS response.


### PR DESCRIPTION
Without the NetKnights dictionary installed, the serial from rlm_per.ini throws errors, visible in debug mode. 
This PR comments the lines by default as they are anyway seldom used.