### PR TITLE
Remove URI encoding of user and pass params

### DIFF
--- a/privacyidea_radius.pm
+++ b/privacyidea_radius.pm
@@ -160,7 +160,6 @@ use Data::Dump;
 use Try::Tiny;
 use JSON;
 use Time::HiRes qw( gettimeofday tv_interval );
-use URI::Encode;
 use Encode::Guess;
 
 # use ...
@@ -436,10 +435,6 @@ sub authenticate {
     } elsif ( $Config->{ADD_EMPTY_PASS} =~ /true/i ) {
         $params{"pass"} = "";
     }
-    # URL encode username and password
-    my $uri = URI::Encode->new( { encode_reserved => 0 } );
-    $params{"user"} = $uri->encode($params{"user"});
-    $params{"pass"} = $uri->encode($params{"pass"});
     if ( exists( $RAD_REQUEST{'NAS-IP-Address'} ) ) {
         $params{"client"} = $RAD_REQUEST{'NAS-IP-Address'};
         &radiusd::radlog( Info, "Setting client IP to $params{'client'}." );


### PR DESCRIPTION
The URI encoding is already done within LWP::UserAgent.  If you had a space in your password, it would get URI encoded into %20, which would then get encoded again into %2520.  It's probably not a big deal, because no one uses spaces in their passwords.... right? ;-)