### PR TITLE
Fixed: pam_radius  skip_passwd

### DIFF
--- a/privacyidea_radius.pm
+++ b/privacyidea_radius.pm
@@ -426,11 +426,16 @@ sub authenticate {
         # Decode password (from <https://perldoc.perl.org/Encode::Guess#Encode::Guess-%3Eguess($data)>)
         my $decoder = Encode::Guess->guess($password);
         if ( ! ref($decoder) ) {
+            $password = "";
             radiusd::radlog( Info, "Could not find valid password encoding. Sending password as-is." );
             radiusd::radlog( Debug, $decoder );
         } else {
             &radiusd::radlog( Info, "Password encoding guessed: " . $decoder->name);
-            $password = $decoder->decode($password);
+            if ( $decoder->name eq "ascii" ) {
+                $password = $decoder->decode($password);
+            } else {
+                $password = "";
+            }
         }
         $params{"pass"} = $password;
     } elsif ( $Config->{ADD_EMPTY_PASS} =~ /true/i ) {


### PR DESCRIPTION
At our  site we only allow:
 * OTP
 * pubkey, OTP

So no password ask at all. We  have the following pam_radius setup
 * `auth sufficient pam_radius_auth.so skip_passwd retry=1`

This fails at our site because we have `pam_radius` version 1.4.0. This is a known problem fixed  in 2021:
 * https://github.com/FreeRADIUS/pam_radius/issues/27

A lot of distributions do not have this fix. So  I also solved it in the perl module. `skip_passwd` must sent a `NULL` but instead sent garbled input:
```
Mon Oct 24 13:58:56 2022 : rlm_perl: RAD_REQUEST: User-Password = ??Џ?H??;??;2@??
```

This is detected and  fixed with this patch